### PR TITLE
Better tests, better `__main__.py`, no duplicates on teams

### DIFF
--- a/src/p2lab/__main__.py
+++ b/src/p2lab/__main__.py
@@ -6,7 +6,12 @@ import asyncio
 import numpy as np
 
 from p2lab.genetic.genetic import genetic_algorithm
-from p2lab.genetic.operations import build_crossover_fn
+from p2lab.genetic.operations import (
+    build_crossover_fn,
+    locus_swap,
+    sample_swap,
+    slot_swap,
+)
 from p2lab.pokemon.premade import gen_1_pokemon
 from p2lab.pokemon.teams import generate_teams, import_pool
 
@@ -26,7 +31,14 @@ async def main_loop(
     # generate the pool
     pool = import_pool(gen_1_pokemon())
     seed_teams = generate_teams(pool, num_teams, team_size, unique=unique)
-    crossover_fn = build_crossover_fn(crossover) if crossover is not None else None
+    function_map = {
+        "sample_swap": sample_swap,
+        "slot_swap": slot_swap,
+        "locus_swap": locus_swap,
+    }
+    crossover_fn = (
+        build_crossover_fn(function_map[crossover]) if crossover is not None else None
+    )
 
     # log the parameters
     print("Running genetic algorithm with the following parameters:")

--- a/src/p2lab/__main__.py
+++ b/src/p2lab/__main__.py
@@ -150,6 +150,8 @@ def main():
             p1=args["p1"],
             p2=args["p2"],
             battles_per_match=args["battles_per_match"],
+            write_every=args["write_every"],
+            write_path=args["write_path"],
         )
     )
 

--- a/src/p2lab/__main__.py
+++ b/src/p2lab/__main__.py
@@ -80,13 +80,13 @@ def parse_args():
     )
     parser.add_argument(
         "--p1",
-        help - "Name of the first player",
+        help="Name of the first player",
         type=str,
         default="Player 1",
     )
     parser.add_argument(
         "--p2",
-        help - "Name of the second player",
+        help="Name of the second player",
         type=str,
         default="Player 2",
     )

--- a/src/p2lab/__main__.py
+++ b/src/p2lab/__main__.py
@@ -11,7 +11,9 @@ from p2lab.pokemon.premade import gen_1_pokemon
 from p2lab.pokemon.teams import generate_teams, import_pool
 
 
-async def main_loop(num_teams, team_size, num_generations, unique, crossover, p1, p2):
+async def main_loop(
+    num_teams, team_size, num_generations, battles_per_match, unique, crossover, p1, p2
+):
     # generate the pool
     pool = import_pool(gen_1_pokemon())
     seed_teams = generate_teams(pool, num_teams, team_size, unique=unique)
@@ -23,7 +25,7 @@ async def main_loop(num_teams, team_size, num_generations, unique, crossover, p1
     print(f"Team size: {team_size}")
     print(f"Number of generations: {num_generations}")
     print(f"Unique teams: {unique}")
-    print(f"Crossover: {crossover_fn.__name__ if crossover_fn is not None else 'none'}")
+    print(f"Crossover: {crossover.__name__ if crossover is not None else 'none'}")
     print(f"Player 1: {p1}")
     print(f"Player 2: {p2}")
     # run the genetic algorithm
@@ -36,9 +38,10 @@ async def main_loop(num_teams, team_size, num_generations, unique, crossover, p1
         progress_bars=True,
         mutate_with_fitness=crossover_fn is None,
         crossover_fn=crossover_fn,
-        mutate_k=1,
+        mutate_k=3,
         player_1_name=p1,
         player_2_name=p2,
+        battles_per_match=battles_per_match,
     )
 
     print("Best team:")
@@ -100,6 +103,12 @@ def parse_args():
         type=str,
         default="Player 2",
     )
+    parser.add_argument(
+        "--battles-per-match",
+        help="Number of battles per match",
+        type=int,
+        default=3,
+    )
     return vars(parser.parse_args())
 
 
@@ -117,6 +126,7 @@ def main():
             crossover=args["crossover"],
             p1=args["p1"],
             p2=args["p2"],
+            battles_per_match=args["battles_per_match"],
         )
     )
 

--- a/src/p2lab/__main__.py
+++ b/src/p2lab/__main__.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import argparse
 import asyncio
+from pathlib import Path
 
 import numpy as np
 
@@ -28,6 +29,10 @@ async def main_loop(
     write_every,
     write_path,
 ):
+    if write_path is not None:
+        write_path = Path(write_path)
+        if not write_path.exists():
+            write_path.mkdir()
     # generate the pool
     pool = import_pool(gen_1_pokemon())
     seed_teams = generate_teams(pool, num_teams, team_size, unique=unique)
@@ -142,7 +147,7 @@ def parse_args():
         "--write-path",
         help="Path to write to",
         type=str,
-        default=".",
+        default="./results",
     )
     return vars(parser.parse_args())
 

--- a/src/p2lab/__main__.py
+++ b/src/p2lab/__main__.py
@@ -12,7 +12,16 @@ from p2lab.pokemon.teams import generate_teams, import_pool
 
 
 async def main_loop(
-    num_teams, team_size, num_generations, battles_per_match, unique, crossover, p1, p2
+    num_teams,
+    team_size,
+    num_generations,
+    battles_per_match,
+    unique,
+    crossover,
+    p1,
+    p2,
+    write_every,
+    write_path,
 ):
     # generate the pool
     pool = import_pool(gen_1_pokemon())
@@ -42,6 +51,8 @@ async def main_loop(
         player_1_name=p1,
         player_2_name=p2,
         battles_per_match=battles_per_match,
+        write_every=write_every,
+        write_path=write_path,
     )
 
     print("Best team:")
@@ -108,6 +119,18 @@ def parse_args():
         help="Number of battles per match",
         type=int,
         default=3,
+    )
+    parser.add_argument(
+        "--write-every",
+        help="Write every N generations",
+        type=int,
+        default=10,
+    )
+    parser.add_argument(
+        "--write-path",
+        help="Path to write to",
+        type=str,
+        default=".",
     )
     return vars(parser.parse_args())
 

--- a/src/p2lab/__main__.py
+++ b/src/p2lab/__main__.py
@@ -34,7 +34,7 @@ async def main_loop(
     print(f"Team size: {team_size}")
     print(f"Number of generations: {num_generations}")
     print(f"Unique teams: {unique}")
-    print(f"Crossover: {crossover.__name__ if crossover is not None else 'none'}")
+    print(f"Crossover: {crossover if crossover is not None else 'none'}")
     print(f"Player 1: {p1}")
     print(f"Player 2: {p2}")
     # run the genetic algorithm

--- a/src/p2lab/__main__.py
+++ b/src/p2lab/__main__.py
@@ -16,6 +16,16 @@ async def main_loop(num_teams, team_size, num_generations, unique, crossover, p1
     pool = import_pool(gen_1_pokemon())
     seed_teams = generate_teams(pool, num_teams, team_size, unique=unique)
     crossover_fn = build_crossover_fn(crossover) if crossover is not None else None
+
+    # log the parameters
+    print("Running genetic algorithm with the following parameters:")
+    print(f"Number of teams: {num_teams}")
+    print(f"Team size: {team_size}")
+    print(f"Number of generations: {num_generations}")
+    print(f"Unique teams: {unique}")
+    print(f"Crossover: {crossover_fn.__name__ if crossover_fn is not None else 'none'}")
+    print(f"Player 1: {p1}")
+    print(f"Player 2: {p2}")
     # run the genetic algorithm
     teams, fitnesses = await genetic_algorithm(
         pokemon_pool=pool,

--- a/src/p2lab/__main__.py
+++ b/src/p2lab/__main__.py
@@ -38,7 +38,7 @@ async def main_loop(
         progress_bars=True,
         mutate_with_fitness=crossover_fn is None,
         crossover_fn=crossover_fn,
-        mutate_k=3,
+        mutate_k=team_size - 1,
         player_1_name=p1,
         player_2_name=p2,
         battles_per_match=battles_per_match,

--- a/src/p2lab/__main__.py
+++ b/src/p2lab/__main__.py
@@ -32,9 +32,9 @@ async def main_loop(
     pool = import_pool(gen_1_pokemon())
     seed_teams = generate_teams(pool, num_teams, team_size, unique=unique)
     function_map = {
-        "sample_swap": sample_swap,
-        "slot_swap": slot_swap,
-        "locus_swap": locus_swap,
+        "sample": sample_swap,
+        "slot": slot_swap,
+        "locus": locus_swap,
     }
     crossover_fn = (
         build_crossover_fn(function_map[crossover]) if crossover is not None else None

--- a/src/p2lab/__main__.py
+++ b/src/p2lab/__main__.py
@@ -11,7 +11,7 @@ from p2lab.pokemon.premade import gen_1_pokemon
 from p2lab.pokemon.teams import generate_teams, import_pool
 
 
-async def main_loop(num_teams, team_size, num_generations, unique, crossover):
+async def main_loop(num_teams, team_size, num_generations, unique, crossover, p1, p2):
     # generate the pool
     pool = import_pool(gen_1_pokemon())
     seed_teams = generate_teams(pool, num_teams, team_size, unique=unique)
@@ -27,6 +27,8 @@ async def main_loop(num_teams, team_size, num_generations, unique, crossover):
         mutate_with_fitness=crossover_fn is None,
         crossover_fn=crossover_fn,
         mutate_k=1,
+        player_1_name=p1,
+        player_2_name=p2,
     )
 
     print("Best team:")
@@ -76,6 +78,18 @@ def parse_args():
         choices=["locus", "slot", "sample"],
         default=None,
     )
+    parser.add_argument(
+        "--p1",
+        help - "Name of the first player",
+        type=str,
+        default="Player 1",
+    )
+    parser.add_argument(
+        "--p2",
+        help - "Name of the second player",
+        type=str,
+        default="Player 2",
+    )
     return vars(parser.parse_args())
 
 
@@ -91,6 +105,8 @@ def main():
             num_generations=args["generations"],
             unique=args["unique"],
             crossover=args["crossover"],
+            p1=args["p1"],
+            p2=args["p2"],
         )
     )
 

--- a/src/p2lab/genetic/genetic.py
+++ b/src/p2lab/genetic/genetic.py
@@ -186,15 +186,18 @@ async def genetic_algorithm(
             print(f"Top fitness: {fitness[np.argmax(fitness)]}")
 
         if write_every is not None and i % write_every == 0:
-            if not Path.exists(write_path / f"generation_{i}"):
-                Path.mkdir(write_path / f"generation_{i}")
-            sorted_fitness = np.argsort(fitness)[::-1]
-            for j, team in enumerate(teams[sorted_fitness]):
-                team_path = Path(
-                    write_path
-                    / f"generation_{i}"
-                    / f"team_{j}_fitness_{fitness[j]:.3f}.txt"
+            if not Path.exists(Path(write_path) / Path(f"generation_{i}")):
+                Path.mkdir(Path(write_path) / Path(f"generation_{i}"))
+            sorted_teams = sorted(
+                teams, key=lambda x: fitness[teams.index(x)], reverse=True
+            )
+            for j, team in enumerate(sorted_teams[:5]):
+                team_path = (
+                    Path(write_path)
+                    / Path(f"generation_{i}")
+                    / Path(f"team_{j}_fitness_{fitness[j]:.3f}.txt")
                 )
+                print(team)
                 team.to_file(team_path)
 
         # Run simulations

--- a/src/p2lab/genetic/genetic.py
+++ b/src/p2lab/genetic/genetic.py
@@ -148,6 +148,7 @@ async def genetic_algorithm(
             # If mutating with fitness, skip the crossover step. Otherwise, crossover +
             # mutate.
             if mutate_with_fitness:
+                print(f"current length of teams: {len(new_teams)}")
                 teams = fitness_mutate(
                     teams=new_teams,
                     num_pokemon=team_size,
@@ -156,6 +157,7 @@ async def genetic_algorithm(
                     allow_all=allow_all,
                     k=mutate_k,
                 )
+                print(f"new length of teams: {len(teams)}")
 
             else:
                 # Mutate the new teams

--- a/src/p2lab/genetic/genetic.py
+++ b/src/p2lab/genetic/genetic.py
@@ -35,6 +35,8 @@ async def genetic_algorithm(
     num_generations: int = 500,
     fitness_kwargs: dict | None = None,
     progress_bars: bool = True,
+    player_1_name: str = "Player 1",
+    player_2_name: str = "Player 2",
 ) -> Team:
     """
     A genetic evolution algorithm for optimising pokemon team selection.
@@ -88,10 +90,10 @@ async def genetic_algorithm(
     matches = match_fn(seed_teams)
 
     player_1 = SimpleHeuristicsPlayer(
-        PlayerConfiguration("Player 1", None), battle_format=battle_format
+        PlayerConfiguration(player_1_name, None), battle_format=battle_format
     )
     player_2 = SimpleHeuristicsPlayer(
-        PlayerConfiguration("Player 2", None), battle_format=battle_format
+        PlayerConfiguration(player_2_name, None), battle_format=battle_format
     )
 
     print("Generation 0:")

--- a/src/p2lab/genetic/genetic.py
+++ b/src/p2lab/genetic/genetic.py
@@ -91,10 +91,14 @@ async def genetic_algorithm(
     matches = match_fn(seed_teams)
 
     player_1 = SimpleHeuristicsPlayer(
-        PlayerConfiguration(player_1_name, None), battle_format=battle_format
+        PlayerConfiguration(player_1_name, None),
+        battle_format=battle_format,
+        log_level=30,
     )
     player_2 = SimpleHeuristicsPlayer(
-        PlayerConfiguration(player_2_name, None), battle_format=battle_format
+        PlayerConfiguration(player_2_name, None),
+        battle_format=battle_format,
+        log_level=30,
     )
 
     print("Generation 0:")

--- a/src/p2lab/genetic/genetic.py
+++ b/src/p2lab/genetic/genetic.py
@@ -4,6 +4,7 @@ __all__ = ("genetic_algorithm",)
 
 from typing import TYPE_CHECKING, Callable
 
+import numpy as np
 from poke_env import PlayerConfiguration
 from poke_env.player import SimpleHeuristicsPlayer
 
@@ -16,7 +17,6 @@ if TYPE_CHECKING:
     from p2lab.pokemon.teams import Team
 
 
-# TODO: account for team size of 1
 async def genetic_algorithm(
     pokemon_pool: list[str],  # list of all valid pokemon names
     seed_teams: list[Team],  # list of teams to seed the algorithm with
@@ -37,6 +37,7 @@ async def genetic_algorithm(
     progress_bars: bool = True,
     player_1_name: str = "Player 1",
     player_2_name: str = "Player 2",
+    print_top_teams: bool = True,
 ) -> Team:
     """
     A genetic evolution algorithm for optimising pokemon team selection.
@@ -148,7 +149,6 @@ async def genetic_algorithm(
             # If mutating with fitness, skip the crossover step. Otherwise, crossover +
             # mutate.
             if mutate_with_fitness:
-                print(f"current length of teams: {len(new_teams)}")
                 teams = fitness_mutate(
                     teams=new_teams,
                     num_pokemon=team_size,
@@ -157,7 +157,6 @@ async def genetic_algorithm(
                     allow_all=allow_all,
                     k=mutate_k,
                 )
-                print(f"new length of teams: {len(teams)}")
 
             else:
                 # Mutate the new teams
@@ -173,7 +172,10 @@ async def genetic_algorithm(
         # Generate matches from list of teams
         matches = match_fn(teams)
 
-        print(f"Generation {i + 1}:")
+        if print_top_teams:
+            print(f"Generation {i + 1}:")
+            print(f"Top team: {teams[np.argmax(fitness)].names}")
+            print(f"Top fitness: {fitness[np.argmax(fitness)]}")
 
         # Run simulations
         results = await run_battles(

--- a/src/p2lab/genetic/genetic.py
+++ b/src/p2lab/genetic/genetic.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 __all__ = ("genetic_algorithm",)
 
+from pathlib import Path
 from typing import TYPE_CHECKING, Callable
 
 import numpy as np
@@ -39,6 +40,8 @@ async def genetic_algorithm(
     player_2_name: str = "Player 2",
     print_top_teams: bool = True,
     player_log_level: int = 30,
+    write_every: int | None = None,
+    write_path: str | None = None,
 ) -> Team:
     """
     A genetic evolution algorithm for optimising pokemon team selection.
@@ -181,6 +184,18 @@ async def genetic_algorithm(
             print(f"Generation {i + 1}:")
             print(f"Top team: {teams[np.argmax(fitness)].names}")
             print(f"Top fitness: {fitness[np.argmax(fitness)]}")
+
+        if write_every is not None and i % write_every == 0:
+            if not Path.exists(write_path / f"generation_{i}"):
+                Path.mkdir(write_path / f"generation_{i}")
+            sorted_fitness = np.argsort(fitness)[::-1]
+            for j, team in enumerate(teams[sorted_fitness]):
+                team_path = Path(
+                    write_path
+                    / f"generation_{i}"
+                    / f"team_{j}_fitness_{fitness[j]:.3f}.txt"
+                )
+                team.to_file(team_path)
 
         # Run simulations
         results = await run_battles(

--- a/src/p2lab/genetic/genetic.py
+++ b/src/p2lab/genetic/genetic.py
@@ -38,6 +38,7 @@ async def genetic_algorithm(
     player_1_name: str = "Player 1",
     player_2_name: str = "Player 2",
     print_top_teams: bool = True,
+    player_log_level: int = 30,
 ) -> Team:
     """
     A genetic evolution algorithm for optimising pokemon team selection.
@@ -93,12 +94,12 @@ async def genetic_algorithm(
     player_1 = SimpleHeuristicsPlayer(
         PlayerConfiguration(player_1_name, None),
         battle_format=battle_format,
-        log_level=30,
+        log_level=player_log_level,
     )
     player_2 = SimpleHeuristicsPlayer(
         PlayerConfiguration(player_2_name, None),
         battle_format=battle_format,
-        log_level=30,
+        log_level=player_log_level,
     )
 
     print("Generation 0:")

--- a/src/p2lab/genetic/operations.py
+++ b/src/p2lab/genetic/operations.py
@@ -230,21 +230,20 @@ def sample_swap(
     team1: list[str],
     team2: list[str],
     num_pokemon: int,
-    with_replacement: bool = True,
+    with_replacement: bool = False,
 ) -> tuple(list[str], list[str]):
     """
     A method of performing the crossover. This method treats the pokemon
     in the two teams as a population and samples from them to create two new
     teams.
 
-    Can be done with or without replacement. Generally more interesting with
-    replacement and so defaults to with replacement.
+    Can be done with or without replacement.
 
     Args:
         team1: List of pokemon in team 1
         team2: List of pokemon in team 2
         num_pokemon: Number of pokemon in each team
-        with_replacement: Whether to sample with our without replacement.
+        with_replacement: Whether to sample with or without replacement.
     """
 
     # Population to sample from and indices
@@ -311,7 +310,7 @@ def mutate(
             mutate_indices = np.random.choice(range(num_pokemon), size=k, replace=False)
 
             new_pokemon = np.random.choice(
-                pokemon_population, size=k, replace=True
+                pokemon_population, size=k, replace=False
             )  # open to parameterising the replace
             team.pokemon[mutate_indices] = new_pokemon
 
@@ -356,9 +355,12 @@ def fitness_mutate(
                 k = random.sample(range(n, num_pokemon - n), k=1)[0]
 
             # Randomly swap k members of the team out with pokemon from the general pop
+            # IMPORTANT: ensure that no team has the same pokemon in it
             mutate_indices = np.random.choice(range(num_pokemon), size=k, replace=False)
             new_pokemon = np.random.choice(
-                pokemon_population, size=k, replace=True
+                pokemon_population,
+                size=k,
+                replace=False,  # replace would create duplicates
             )  # open to parameterising the replace
             team.pokemon[mutate_indices] = new_pokemon
 

--- a/src/p2lab/genetic/operations.py
+++ b/src/p2lab/genetic/operations.py
@@ -231,6 +231,7 @@ def sample_swap(
     team2: list[str],
     num_pokemon: int,
     with_replacement: bool = False,
+    **kwargs,
 ) -> tuple(list[str], list[str]):
     """
     A method of performing the crossover. This method treats the pokemon

--- a/src/p2lab/genetic/operations.py
+++ b/src/p2lab/genetic/operations.py
@@ -230,7 +230,6 @@ def sample_swap(
     team1: list[str],
     team2: list[str],
     num_pokemon: int,
-    with_replacement: bool = False,
     **kwargs,
 ) -> tuple(list[str], list[str]):
     """
@@ -238,13 +237,15 @@ def sample_swap(
     in the two teams as a population and samples from them to create two new
     teams.
 
-    Can be done with or without replacement.
-
     Args:
         team1: List of pokemon in team 1
         team2: List of pokemon in team 2
         num_pokemon: Number of pokemon in each team
-        with_replacement: Whether to sample with or without replacement.
+
+    Returns:
+        Two new teams
+
+    note: replacement is set to False to enforce the same pokemon cannot be in both teams
     """
 
     # Population to sample from and indices
@@ -255,23 +256,37 @@ def sample_swap(
     team1_indices = np.random.choice(
         indices,
         size=num_pokemon,
-        replace=with_replacement,
+        replace=False,
     )
 
-    # For team 2, change behaviour conditional on replacement
-    if with_replacement:
-        team2_indices = list(
-            np.random.choice(
-                indices,
-                size=num_pokemon,
-                replace=with_replacement,
-            )
+    team1_pokemon = population[team1_indices]
+    team1_names = [p.formatted.split("|")[0] for p in team1_pokemon]
+
+    # Get indices for team 2, which are just the indices not in team 1
+    team2_indices = list(set(indices) - set(team1_indices))
+    team2_pokemon = population[team2_indices]
+    team2_names = [p.formatted.split("|")[0] for p in team2_pokemon]
+
+    # ensure we don't sample the same pokemon twice on either team
+    while len(set(team1_names)) != len(team1_names) or len(set(team2_names)) != len(
+        team2_names
+    ):
+        print("Found duplicate pokemon, resampling...")
+        team1_indices = np.random.choice(
+            indices,
+            size=num_pokemon,
+            replace=False,
         )
-    else:
+
+        team1_pokemon = population[team1_indices]
+        team1_names = [p.formatted.split("|")[0] for p in team1_pokemon]
+
         team2_indices = list(set(indices) - set(team1_indices))
+        team2_pokemon = population[team2_indices]
+        team2_names = [p.formatted.split("|")[0] for p in team2_pokemon]
 
     # Return teams
-    return list(population[team1_indices]), list(population(team2_indices))
+    return list(team1_pokemon), list(team2_pokemon)
 
 
 ### Mutation Operations

--- a/src/p2lab/genetic/operations.py
+++ b/src/p2lab/genetic/operations.py
@@ -28,7 +28,7 @@ def selection(
     """
 
     # Sample indices with replacement to produce new teams + fitnesses
-    old_indices = list(range(num_teams))
+    old_indices = list(range(len(teams)))
     new_indices = random.choices(old_indices, k=num_teams)
 
     # New teams and fitness

--- a/src/p2lab/genetic/operations.py
+++ b/src/p2lab/genetic/operations.py
@@ -343,6 +343,8 @@ def fitness_mutate(
         k: Number of team members to mutate. If set to None, this number will
            be random.
     """
+    new_teams = []
+
     for index, team in enumerate(teams):
         # Each team faces a random chance of mutation
         if np.random.choice(
@@ -363,6 +365,23 @@ def fitness_mutate(
                 size=k,
                 replace=False,  # replace would create duplicates
             )  # open to parameterising the replace
-            team.pokemon[mutate_indices] = new_pokemon
+            # check that these new pokemon are not already in the team
+            names = [p.formatted.split("|")[0] for p in new_pokemon]
+            while any(name in team.names for name in names):
+                print("Found duplicate pokemon, resampling...")
+                new_pokemon = np.random.choice(
+                    pokemon_population,
+                    size=k,
+                    replace=False,  # replace would create duplicates
+                )
+                names = [p.formatted.split("|")[0] for p in new_pokemon]
+            # Create new team with the mutated pokemon and the rest of the team
+            old_pokemon = np.array(team.pokemon)[
+                [i for i in range(num_pokemon) if i not in mutate_indices]
+            ]
+            new_team = [*new_pokemon, *old_pokemon]
+            new_teams.append(Team(new_team))
+        else:
+            new_teams.append(team)
 
-    return teams
+    return new_teams

--- a/src/p2lab/pokemon/teams.py
+++ b/src/p2lab/pokemon/teams.py
@@ -10,18 +10,30 @@ __all__ = (
 )
 
 import sys
+from dataclasses import dataclass
 from pathlib import Path
 from subprocess import check_output
+from typing import Any
 
 import numpy as np
 from poke_env.teambuilder import Teambuilder
 from tqdm import tqdm
 
+Pokemon = Any
 
+
+@dataclass(frozen=True)
 class Team:
+    pokemon: tuple[Pokemon]
+    names: tuple[str]
+
     def __init__(self, pokemon) -> None:
-        self.pokemon = np.array(deepcopy(pokemon))
-        self.first_name = self.pokemon[0].formatted.split("|")[0]
+        names = [p.formatted.split("|")[0] for p in pokemon]
+        if len(names) != len(set(names)):
+            msg = f"Team cannot have duplicate pokemon names: tried to create team of {names}"
+            raise ValueError(msg)
+        object.__setattr__(self, "pokemon", tuple(deepcopy(pokemon)))
+        object.__setattr__(self, "names", tuple(names))
 
     def to_packed_str(self) -> str:
         return "]".join([mon.formatted for mon in self.pokemon])

--- a/src/p2lab/pokemon/teams.py
+++ b/src/p2lab/pokemon/teams.py
@@ -25,7 +25,6 @@ Pokemon = Any
 @dataclass(frozen=True)
 class Team:
     pokemon: tuple[Pokemon]
-    names: tuple[str]
 
     def __init__(self, pokemon) -> None:
         if len(pokemon) > 6:
@@ -36,7 +35,10 @@ class Team:
             msg = f"Team cannot have duplicate pokemon names: tried to create team of {names}"
             raise ValueError(msg)
         object.__setattr__(self, "pokemon", tuple(deepcopy(pokemon)))
-        object.__setattr__(self, "names", tuple(names))
+
+    @property
+    def names(self) -> tuple[str]:
+        return tuple(p.formatted.split("|")[0] for p in self.pokemon)
 
     def to_packed_str(self) -> str:
         return "]".join([mon.formatted for mon in self.pokemon])
@@ -46,6 +48,16 @@ class Team:
 
     def __getitem__(self, index: int) -> Pokemon:
         return self.pokemon[index]
+
+    def __iter__(self):
+        return iter(self.pokemon)
+
+    def __repr__(self) -> str:
+        return f"Team({self.names})"
+
+    def to_file(self, filename: str) -> None:
+        with Path.open(filename, "w") as f:
+            f.write(self.to_packed_str())
 
 
 class _Builder(Teambuilder):

--- a/src/p2lab/pokemon/teams.py
+++ b/src/p2lab/pokemon/teams.py
@@ -28,6 +28,9 @@ class Team:
     names: tuple[str]
 
     def __init__(self, pokemon) -> None:
+        if len(pokemon) > 6:
+            msg = f"Team cannot have more than 6 pokemon: tried to create team of {pokemon}"
+            raise ValueError(msg)
         names = [p.formatted.split("|")[0] for p in pokemon]
         if len(names) != len(set(names)):
             msg = f"Team cannot have duplicate pokemon names: tried to create team of {names}"
@@ -37,6 +40,12 @@ class Team:
 
     def to_packed_str(self) -> str:
         return "]".join([mon.formatted for mon in self.pokemon])
+
+    def __len__(self) -> int:
+        return len(self.pokemon)
+
+    def __getitem__(self, index: int) -> Pokemon:
+        return self.pokemon[index]
 
 
 class _Builder(Teambuilder):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,9 +2,14 @@ from __future__ import annotations
 
 import pytest
 
-from p2lab.pokemon import pokefactory
+from p2lab.pokemon import pokefactory, premade, teams
 
 
 @pytest.fixture()
 def default_factory():
     return pokefactory.PokeFactory()
+
+
+@pytest.fixture()
+def gen_1_pool():
+    return teams.import_pool(premade.gen_1_pokemon())

--- a/tests/test_pokedex.py
+++ b/tests/test_pokedex.py
@@ -1,84 +1,63 @@
 from __future__ import annotations
 
 import numpy as np
-
-from p2lab.pokemon import pokefactory
-
-
-def test_pokedex():
-    p = pokefactory.PokeFactory()
-    assert p is not None
+import pytest
 
 
-def test_eevee_fetch():
-    p = pokefactory.PokeFactory()
-    eevee = p.get_pokemon_by_dexnum(133)
+def test_eevee_fetch(default_factory):
+    eevee = default_factory.get_pokemon_by_dexnum(133)
     assert eevee["baseSpecies"].lower() == "eevee"
 
 
-def test_bulbasaur_fetch():
-    p = pokefactory.PokeFactory()
-    bulb = p.get_pokemon_by_dexnum(1)
+def test_bulbasaur_fetch(default_factory):
+    bulb = default_factory.get_pokemon_by_dexnum(1)
     assert bulb["baseSpecies"].lower() == "bulbasaur"
 
 
-def test_eevee_moves():
-    p = pokefactory.PokeFactory()
-    eevee_moves = p.get_allowed_moves(133)
+def test_eevee_moves(default_factory):
+    eevee_moves = default_factory.get_allowed_moves(133)
     assert len(eevee_moves) > 0
 
 
-def test_bulbasaur_moves():
-    p = pokefactory.PokeFactory()
-    bulb_moves = p.get_allowed_moves(1)
+def test_bulbasaur_moves(default_factory):
+    bulb_moves = default_factory.get_allowed_moves(1)
     assert len(bulb_moves) > 0
 
 
-def test_eevee_is_created():
-    p = pokefactory.PokeFactory()
-    eevee = p.make_pokemon(133)
+def test_eevee_is_created(default_factory):
+    eevee = default_factory.make_pokemon(133)
     assert eevee is not None
 
 
-def test_eevee_is_created_with_moves():
-    p = pokefactory.PokeFactory()
-    eevee = p.make_pokemon(133, moves=["tackle", "growl"])
+def test_eevee_is_created_with_moves(default_factory):
+    eevee = default_factory.make_pokemon(133, moves=["tackle", "growl"])
     assert eevee is not None
 
 
-def test_random_pokemon_is_created_with_moves():
-    p = pokefactory.PokeFactory()
+def test_random_pokemon_is_created_with_moves(default_factory):
     dexnum = np.random.randint(1, 151)
     while dexnum == 132:
         dexnum = np.random.randint(1, 151)
-    poke = p.make_pokemon(dexnum=dexnum, generate_moveset=True)
-    assert len(poke.moves) == 4
+    poke = default_factory.make_pokemon(dexnum=dexnum, generate_moveset=True)
+    assert 1 < len(poke.moves) <= 4
 
 
-def test_ditto_is_created_with_moves():
-    p = pokefactory.PokeFactory()
-    ditto = p.make_pokemon(132)
+def test_ditto_is_created_with_moves(default_factory):
+    ditto = default_factory.make_pokemon(132)
     assert len(ditto.moves) == 1
 
 
-def test_all_gen1_pokemon_can_be_created():
-    p = pokefactory.PokeFactory()
+def test_all_gen1_pokemon_can_be_created(default_factory):
     for dexnum in range(1, 152):
-        poke = p.make_pokemon(dexnum=dexnum, generate_moveset=True)
-        assert len(poke.moves) > 0
+        poke = default_factory.make_pokemon(dexnum=dexnum, generate_moveset=True)
+        assert 1 < len(poke.moves) <= 4
 
 
-def test_invalid_dex_raised():
-    p = pokefactory.PokeFactory()
-    try:
-        p.make_pokemon(dexnum=0)
-    except ValueError:
-        assert True
-    else:
-        raise AssertionError()
+def test_invalid_dex_raised(default_factory):
+    with pytest.raises(ValueError, match="dexnum must be between 1 and 151"):
+        default_factory.make_pokemon(dexnum=0)
 
 
-def test_adding_item_to_pokemon():
-    p = pokefactory.PokeFactory()
-    ditto = p.make_pokemon(132, item="choice scarf")
+def test_adding_item_to_pokemon(default_factory):
+    ditto = default_factory.make_pokemon(132, item="choice scarf")
     assert ditto.item == "choice scarf"

--- a/tests/test_pokedex.py
+++ b/tests/test_pokedex.py
@@ -39,7 +39,7 @@ def test_random_pokemon_is_created_with_moves(default_factory):
     while dexnum == 132:
         dexnum = np.random.randint(1, 151)
     poke = default_factory.make_pokemon(dexnum=dexnum, generate_moveset=True)
-    assert 1 < len(poke.moves) <= 4
+    assert 1 <= len(poke.moves) <= 4
 
 
 def test_ditto_is_created_with_moves(default_factory):
@@ -50,11 +50,11 @@ def test_ditto_is_created_with_moves(default_factory):
 def test_all_gen1_pokemon_can_be_created(default_factory):
     for dexnum in range(1, 152):
         poke = default_factory.make_pokemon(dexnum=dexnum, generate_moveset=True)
-        assert 1 < len(poke.moves) <= 4
+        assert 1 <= len(poke.moves) <= 4
 
 
 def test_invalid_dex_raised(default_factory):
-    with pytest.raises(ValueError, match="dexnum must be between 1 and 151"):
+    with pytest.raises(ValueError, match="Dex number must be greater than 0"):
         default_factory.make_pokemon(dexnum=0)
 
 

--- a/tests/test_teams.py
+++ b/tests/test_teams.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+import pytest
+
+from p2lab.pokemon.teams import Team
+
+
+def test_basic_team_creation(gen_1_pool):
+    team = Team([gen_1_pool[0], gen_1_pool[1], gen_1_pool[2]])
+    assert len(team) == 3
+    assert team[0] == gen_1_pool[0]
+    assert team[1] == gen_1_pool[1]
+    assert team[2] == gen_1_pool[2]
+    assert list(team.names) == ["Bulbasaur", "Ivysaur", "Venusaur"]
+
+
+def test_team_creation_with_duplicates(gen_1_pool):
+    with pytest.raises(ValueError, match="Team cannot have duplicate pokemon"):
+        Team([gen_1_pool[0], gen_1_pool[1], gen_1_pool[2], gen_1_pool[0]])
+
+
+def test_team_creation_with_too_many_pokemon(gen_1_pool):
+    with pytest.raises(ValueError, match="Team cannot have more than 6 pokemon"):
+        Team(gen_1_pool)
+
+
+def test_modifying_pokemon_in_team(gen_1_pool):
+    team = Team([gen_1_pool[0], gen_1_pool[1], gen_1_pool[2]])
+    with pytest.raises(
+        TypeError, match="'Team' object does not support item assignment"
+    ):
+        team[0] = gen_1_pool[7]

--- a/tests/test_teams.py
+++ b/tests/test_teams.py
@@ -8,9 +8,6 @@ from p2lab.pokemon.teams import Team
 def test_basic_team_creation(gen_1_pool):
     team = Team([gen_1_pool[0], gen_1_pool[1], gen_1_pool[2]])
     assert len(team) == 3
-    assert team[0] == gen_1_pool[0]
-    assert team[1] == gen_1_pool[1]
-    assert team[2] == gen_1_pool[2]
     assert list(team.names) == ["Bulbasaur", "Ivysaur", "Venusaur"]
 
 
@@ -24,9 +21,13 @@ def test_team_creation_with_too_many_pokemon(gen_1_pool):
         Team(gen_1_pool)
 
 
-def test_modifying_pokemon_in_team(gen_1_pool):
+def test_no_modifying_pokemon_in_team(gen_1_pool):
     team = Team([gen_1_pool[0], gen_1_pool[1], gen_1_pool[2]])
     with pytest.raises(
         TypeError, match="'Team' object does not support item assignment"
     ):
         team[0] = gen_1_pool[7]
+    with pytest.raises(
+        TypeError, match="'tuple' object does not support item assignment"
+    ):
+        team.pokemon[0] = gen_1_pool[7]

--- a/tests/test_workflow.py
+++ b/tests/test_workflow.py
@@ -1,14 +1,13 @@
 from __future__ import annotations
 
-import numpy as np
 import pytest
 
-from p2lab.genetic.genetic import genetic_algorithm
+from p2lab.__main__ import main_loop
 from p2lab.genetic.operations import (
-    build_crossover_fn,
+    locus_swap,
+    sample_swap,
+    slot_swap,
 )
-from p2lab.pokemon.premade import gen_1_pokemon
-from p2lab.pokemon.teams import generate_teams, import_pool
 
 
 @pytest.mark.asyncio()
@@ -16,46 +15,22 @@ from p2lab.pokemon.teams import generate_teams, import_pool
     ("team_size", "crossover_fn"),
     [
         (1, None),
-        # (2, None),
-        # (6, locus_swap),
-        # (6, slot_swap),
-        # (6, sample_swap),
+        (2, None),
+        (6, locus_swap),
+        (6, slot_swap),
+        (6, sample_swap),
     ],
 )
-async def test_main_loop(team_size, crossover_fn):
+def test_main_loop(event_loop, team_size, crossover_fn):
     num_teams = 10
-    # generate the pool
-    pool = import_pool(gen_1_pokemon())
-    seed_teams = generate_teams(pool, num_teams, team_size, unique=True)
-    crossover_fn = (
-        build_crossover_fn(crossover_fn) if crossover_fn is not None else None
+    num_generations = 10
+    res = event_loop.run_until_complete(
+        main_loop(
+            num_teams=num_teams,
+            team_size=team_size,
+            num_generations=num_generations,
+            unique=True,
+            crossover_fn=crossover_fn,
+        )
     )
-    # run the genetic algorithm
-    teams, fitnesses = await genetic_algorithm(
-        pokemon_pool=pool,
-        seed_teams=seed_teams,
-        num_teams=num_teams,
-        team_size=team_size,
-        num_generations=3,
-        progress_bars=True,
-        crossover_fn=crossover_fn,
-        mutate_with_fitness=crossover_fn is None,
-        mutate_k=1,
-    )
-
-    print("Best team:")
-    best_team = teams[np.argmax(fitnesses)]
-    fitness = fitnesses[np.argmax(fitnesses)]
-    for mon in best_team.pokemon:
-        print(mon.formatted)
-
-    print(f"Fitness: {fitness}")
-
-    print("Worst team:")
-
-    worst_team = teams[np.argmin(fitnesses)]
-    fitness = fitnesses[np.argmin(fitnesses)]
-    for mon in worst_team.pokemon:
-        print(mon.formatted)
-
-    print(f"Fitness: {fitness}")
+    assert res is not None

--- a/tests/test_workflow.py
+++ b/tests/test_workflow.py
@@ -3,27 +3,22 @@ from __future__ import annotations
 import pytest
 
 from p2lab.__main__ import main_loop
-from p2lab.genetic.operations import (
-    locus_swap,
-    sample_swap,
-    slot_swap,
-)
 
 
 @pytest.mark.parametrize(
-    ("team_size", "crossover_fn"),
+    ("team_size", "crossover_string"),
     [
         (1, None),
         (2, None),
-        (6, locus_swap),
-        (6, slot_swap),
-        (6, sample_swap),
+        (6, "locus"),
+        (6, "slot"),
+        (6, "sample"),
     ],
 )
-def test_main_loop(event_loop, team_size, crossover_fn):
+def test_main_loop(event_loop, team_size, crossover_string):
     num_teams = 10
     num_generations = 3
-    crossover_name = crossover_fn.__name__ if crossover_fn is not None else "none"
+    crossover_name = crossover_string if crossover_string is not None else "none"
     player_name = "main-" + str(team_size) + "-" + crossover_name
     event_loop.run_until_complete(
         main_loop(
@@ -31,9 +26,11 @@ def test_main_loop(event_loop, team_size, crossover_fn):
             team_size=team_size,
             num_generations=num_generations,
             unique=True,
-            crossover=crossover_fn,
+            crossover=crossover_string,
             p1=player_name[:15] + " P1",
             p2=player_name[:15] + " P2",
             battles_per_match=3,
+            write_every=None,
+            write_path=None,
         )
     )

--- a/tests/test_workflow.py
+++ b/tests/test_workflow.py
@@ -34,5 +34,6 @@ def test_main_loop(event_loop, team_size, crossover_fn):
             crossover=crossover_fn,
             p1=player_name[:15] + " P1",
             p2=player_name[:15] + " P2",
+            battles_per_match=3,
         )
     )

--- a/tests/test_workflow.py
+++ b/tests/test_workflow.py
@@ -10,7 +10,6 @@ from p2lab.genetic.operations import (
 )
 
 
-@pytest.mark.asyncio()
 @pytest.mark.parametrize(
     ("team_size", "crossover_fn"),
     [
@@ -23,14 +22,17 @@ from p2lab.genetic.operations import (
 )
 def test_main_loop(event_loop, team_size, crossover_fn):
     num_teams = 10
-    num_generations = 10
-    res = event_loop.run_until_complete(
+    num_generations = 3
+    crossover_name = crossover_fn.__name__ if crossover_fn is not None else "none"
+    player_name = "main-" + str(team_size) + "-" + crossover_name
+    event_loop.run_until_complete(
         main_loop(
             num_teams=num_teams,
             team_size=team_size,
             num_generations=num_generations,
             unique=True,
-            crossover_fn=crossover_fn,
+            crossover=crossover_fn,
+            p1=player_name[:15] + " P1",
+            p2=player_name[:15] + " P2",
         )
     )
-    assert res is not None


### PR DESCRIPTION
turns out the use of `deepcopy` in the `Team` class in #36 #40 #41 didn't actually fix our issue -- the *cause* is probably right since it always happens with duplicate pokemon, but this didn't make the pokemon separate from the point of view of the bot.

this fixes the issue indirectly in `fitness_mutate` and `mutate` by forcing a resampling whenever duplicate pokemon are generated for the same team. additionally, there's a hard guard to this in `Team` now which checks the pokemon upon initialisation. 

what's not protected against is modifying the `.pokemon` attribute directly, so I've made this a tuple for now -- needs some ironing out for use in the crossover methods, since they've been designed for numpy arrays. (i cast once or twice atm to get partially around this).